### PR TITLE
Adding computation of initial epsilon for perimeter

### DIFF
--- a/Topology Optimization/Incremental_Scheme.m
+++ b/Topology Optimization/Incremental_Scheme.m
@@ -17,12 +17,11 @@ classdef Incremental_Scheme < handle
             obj.connec=mesh.connec;
             if isempty(settings.epsilon_initial)
                 obj.epsilon_initial = mesh.computeMeanCellSize;
-                obj.epsilon0 = mesh.problem_characterisitc_length;
             else
                 obj.epsilon_initial=settings.epsilon_initial;
             end
             obj.epsilon=obj.epsilon_initial;
-            obj.epsilon0=obj.epsilon_initial;
+            obj.epsilon0=mesh.computeCharacteristicLength;
             obj.incropt.alpha_vol = obj.generate_incr_sequence(1/nsteps,1,nsteps,'linear');
             obj.incropt.alpha_constr = obj.generate_incr_sequence(0,1,nsteps,'linear');
             obj.incropt.alpha_optimality= obj.generate_incr_sequence(0,1,nsteps,'linear');


### PR DESCRIPTION
Adding again the computation of the initial epsilon for the perimeter shape function, which was lost in previous commits.

The perimeter was being computed with a constant epsilon along all the optimization steps, which caused some benchmarks to fail.