### PR TITLE
Fixing Line Linear

### DIFF
--- a/FEM/Interpolation/Line_Linear.m
+++ b/FEM/Interpolation/Line_Linear.m
@@ -17,7 +17,7 @@ classdef Line_Linear < Interpolation
             s = posgp;
             
             obj.shape = [ones(length(posgp),1)-s,s+1]/2;
-            obj.deriv = repmat([-1.0,1.0],1,1,length(posgp));
+            obj.deriv = repmat([-0.5,0.5],1,1,length(posgp));
         end
     end
 end

--- a/tests/FemTests/FemTests.m
+++ b/tests/FemTests/FemTests.m
@@ -17,7 +17,6 @@ classdef FemTests < testRunner
             obj.tests = {...  
                 'test2dMicro';
                 'test2dQuad';                
-                'testStiffnessMatrixGenerator';
                 'test2dTriangle';
                 'test2dStokes_triangle';
                 'test3dTetrahedra';


### PR DESCRIPTION
The problem we had with the integration of lines had to do with the derivatives of the shape funcs, which are defined:

![image](https://user-images.githubusercontent.com/32136457/53286042-c7386880-3768-11e9-95aa-9dc2ae7969e2.png)

The derivatives were set as [-1,1] instead of [-0.5,0.5]

In this PR I also remove one test from FEMTests that  no longer exists (testStifnessMatrixGenerator.m)

Now all tests pass! 